### PR TITLE
Update the map origin even if the center tile is the same one

### DIFF
--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -68,6 +68,11 @@ AerialMapDisplay::AerialMapDisplay() : Display()
                                       this, SLOT(updateDrawUnder()));
   draw_under_property_->setShouldBeSaved(true);
   draw_under_ = draw_under_property_->getValue().toBool();
+  realtime_origin_update_property_ = new BoolProperty("Realtime Origin Update", false,
+                                      "Update option, determines to update the map origin with the latest GNSS data.",
+                                      this, SLOT(updateRealtimeOriginUpdate()));
+  realtime_origin_update_property_->setShouldBeSaved(true);
+  realtime_origin_update_ = realtime_origin_update_property_->getBool();
 
   // properties for map
   tile_url_property_ =
@@ -190,6 +195,11 @@ void AerialMapDisplay::updateDrawUnder()
   }
 
   triggerSceneAssembly();
+}
+
+void AerialMapDisplay::updateRealtimeOriginUpdate()
+{
+  realtime_origin_update_ = realtime_origin_update_property_->getBool();
 }
 
 void AerialMapDisplay::updateTileUrl()
@@ -396,12 +406,12 @@ void AerialMapDisplay::updateCenterTile(sensor_msgs::NavSatFixConstPtr const& ms
   TileId const new_center_tile_id{ tile_url_, tile_coordinates, zoom_ };
   bool const center_tile_changed = (!center_tile_ || !(new_center_tile_id == *center_tile_));
 
-  // if (not center_tile_changed)
-  // {
-  //   // TODO: Maybe we should update the transform here even if the center tile did not change?
-  //   // The localization might have been updated.
-  //   return;
-  // }
+  if (!realtime_origin_update_&& !center_tile_changed)
+  {
+    // TODO: Maybe we should update the transform here even if the center tile did not change?
+    // The localization might have been updated.
+    return;
+  }
 
   ROS_DEBUG_NAMED("rviz_satellite", "Updating center tile");
 

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -396,12 +396,12 @@ void AerialMapDisplay::updateCenterTile(sensor_msgs::NavSatFixConstPtr const& ms
   TileId const new_center_tile_id{ tile_url_, tile_coordinates, zoom_ };
   bool const center_tile_changed = (!center_tile_ || !(new_center_tile_id == *center_tile_));
 
-  if (not center_tile_changed)
-  {
-    // TODO: Maybe we should update the transform here even if the center tile did not change?
-    // The localization might have been updated.
-    return;
-  }
+  // if (not center_tile_changed)
+  // {
+  //   // TODO: Maybe we should update the transform here even if the center tile did not change?
+  //   // The localization might have been updated.
+  //   return;
+  // }
 
   ROS_DEBUG_NAMED("rviz_satellite", "Updating center tile");
 

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -62,6 +62,7 @@ protected Q_SLOTS:
   void updateAlpha();
   void updateTopic();
   void updateDrawUnder();
+  void updateRealtimeOriginUpdate();
   void updateTileUrl();
   void updateZoom();
   void updateBlocks();
@@ -156,11 +157,14 @@ protected:
   IntProperty* blocks_property_;
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
+  BoolProperty* realtime_origin_update_property_;
 
   /// the alpha value of the tile's material
   float alpha_;
   /// determines which render queue to use
   bool draw_under_;
+  /// determines to update the map origin with the latest GNSS data
+  bool realtime_origin_update_;
   /// the URL of the tile server to use
   std::string tile_url_;
   /// the zoom to use (Mercator)


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

The original implementation disables to update the map origin if center tile is not changed.
Although such setting contributes to reduce map downloading, it is inconvenient to use with autonomous vehicles.

<!-- 変更の詳細 -->
## Detail

~This PR just enables the update functions.~
This PR provides a check box to enable/disable the update.

I verified this works well by publishing sensor_msgs/NavSatFix type messages with small displacements (few meters / order of 0.001 longitude).

